### PR TITLE
One api call for up to 5 tokens

### DIFF
--- a/eval_pipeline/openai_api.py
+++ b/eval_pipeline/openai_api.py
@@ -35,6 +35,7 @@ class APIParameters:
     logprobs: Optional[int] = 100
     stop: Optional[list[str]] = None
     echo: bool = False
+    logit_bias: Optional[dict[str, float]] = None
 
 
 OPENAI_API_BASE_URL = "https://api.openai.com/v1/engines"
@@ -80,7 +81,7 @@ def _call_api(
     # not just the top 5
     data = {
         "prompt": prompt,
-        **asdict(api_params),
+        **asdict(api_params, dict_factory=lambda x: {k: v for (k, v) in x if v is not None}),
     }
 
     headers = {


### PR DESCRIPTION
The code currently submits n_classes x GPT-3 prompts, which can double the $ cost. This can be made into a single api call for single token classes by using logit_bias equal to 100 for all the desired classes, which I believe adds 100 before performing log_softmax. This will preserve the relative probabilities, but the total_logprob will be wrong (always 0), but this shouldn't matter during the loss plotting. The results should be 100% identical, modulo any small numerical issues.

The code checks to make sure the conditions are satisfied for this special case before making any calls:
1. All class sequences are single tokens.
2. There are at most 5 unique class tokens across the entire batch.

Otherwise, it will fallback to the main path. There are no ways to specify a different logit_bias per prompt, so the only way to get around (2) is to decrease the batch size.