### PR TITLE
Support variable number of classes per question for classification

### DIFF
--- a/eval_pipeline/plot_loss.py
+++ b/eval_pipeline/plot_loss.py
@@ -135,10 +135,10 @@ def plot_classification_loss(
     dfs = {csv_file.stem: pd.read_csv(csv_file, index_col=0) for csv_file in loss_csvs}
 
     if task_type == "classification_acc":
-        # NOTE: assuming all examples have the same number of classes
-        n_classes = len(literal_eval(str(data_df["classes"][0])))  # type: ignore
+        n_classes_per_example = np.array([len(literal_eval(str(x))) for x in data_df["classes"]])
         # the baseline puts equal probability on each class, so we are considering a uniform distribution
-        baseline = 1 / n_classes
+        baseline_probs = [1 / x for x in n_classes_per_example]
+        baseline = np.mean(baseline_probs)
         output_name = "correct"
         if invert:
             for df in dfs.values():
@@ -148,11 +148,10 @@ def plot_classification_loss(
 
     # NOTE: the default plot type is now loss because that's what we ask for in the submission
     elif task_type == "classification_loss" or task_type == "classification":
-        # NOTE: assuming all examples have the same number of classes
-        n_classes = len(literal_eval(str(data_df["classes"][0])))  # type: ignore
+        n_classes_per_example = [len(literal_eval(str(x))) for x in data_df["classes"]]
         # the baseline puts equal probability on each class, so we are considering a uniform distribution
-        baseline_prob = 1 / n_classes
-        baseline = -np.log(baseline_prob)
+        baseline_losses = [-np.log(1 / x) for x in n_classes_per_example]
+        baseline = np.mean(baseline_losses)
         output_name = "loss"
         if invert:
             for df in dfs.values():

--- a/eval_pipeline/plot_loss.py
+++ b/eval_pipeline/plot_loss.py
@@ -137,8 +137,7 @@ def plot_classification_loss(
     if task_type == "classification_acc":
         n_classes_per_example = np.array([len(literal_eval(str(x))) for x in data_df["classes"]])
         # the baseline puts equal probability on each class, so we are considering a uniform distribution
-        baseline_probs = [1 / x for x in n_classes_per_example]
-        baseline = np.mean(baseline_probs)
+        baseline = (1 / n_classes_per_example).mean()
         output_name = "correct"
         if invert:
             for df in dfs.values():
@@ -148,10 +147,9 @@ def plot_classification_loss(
 
     # NOTE: the default plot type is now loss because that's what we ask for in the submission
     elif task_type == "classification_loss" or task_type == "classification":
-        n_classes_per_example = [len(literal_eval(str(x))) for x in data_df["classes"]]
+        n_classes_per_example = np.array([len(literal_eval(str(x))) for x in data_df["classes"]])
         # the baseline puts equal probability on each class, so we are considering a uniform distribution
-        baseline_losses = [-np.log(1 / x) for x in n_classes_per_example]
-        baseline = np.mean(baseline_losses)
+        baseline = (-np.log(1 / n_classes_per_example)).mean()
         output_name = "loss"
         if invert:
             for df in dfs.values():


### PR DESCRIPTION
The previous public-colab code required csvs to have the same number of classes for each question for classification.

This change makes it so that csvs can have different numbers of classes for each question.

The plotting logic is also modified so that the baseline is correctly calculated based on the number of classes for each question.

The code was tested on the [public GPT3, OPT, and GPT2 colabs](https://github.com/inverse-scaling/prize#links) (by replacing the git repository it pulls from with the PR branch) for the both the `classification` and `classification_acc` metrics. We tested using the following csv: https://github.com/ed1d1a8d/inverse-scaling-eval-pipeline/blob/3434c202a55e85f6b13d0412fbb5b41e9291a7b8/data/test/classification.csv