### PR TITLE
[main] fix target tokenization bug

### DIFF
--- a/eval_pipeline/models.py
+++ b/eval_pipeline/models.py
@@ -177,7 +177,7 @@ class HFModel(Model):
                 class_sequence = example.classes[j]
                 # NOTE: we subtract 1 if OPT because the first token is the start of the sequence
                 target_token_length = (
-                    len(self.tokenizer(class_sequence)["input_ids"])
+                    len(self.tokenizer(class_sequence, add_special_tokens=False)["input_ids"])
                     - self.correction_for_start_token
                 )
                 # we only need the logits for the end sequence


### PR DESCRIPTION
Hi Team, 

I just took a closer look at the evaluation pipeline and found the potential issue below. When calculating the target lengths, the original code did not add the argument `add_special_tokens=False`. While it's fine for GPT-neo and GPT-2 tokenizers as they do not add special tokens during tokenization, this overcounts the OPT BOS token `</s>` towards the target sequence, resulting in a problematic log probability calculation for OPT (and potentially other models, depending on the implementation of their tokenizers). I'd appreciate it a lot if you could confirm and double-check about this. 

Thanks,
Freda
