### PR TITLE
Fix openai models for python >= 3.9, add newer openai mdoels

### DIFF
--- a/eval_pipeline/main.py
+++ b/eval_pipeline/main.py
@@ -130,8 +130,8 @@ def run_model(
     write the results to write_path incrementally."""
     write_path = Path(write_dir, model_name + ".csv")
     # TODO: find a way to avoid having to specify field names ahead of time
-    if task_type in ["classification_loss", "classification", "classification_acc"]:
-        field_names = ["index", "loss", "correct", "predicted", "total_logprob", "ground_truth"]
+    if task_type in ["classification_loss", "classification_acc", "classification"]:
+        field_names = ["index", "loss", "correct", "predicted", "total_logprob"]
     elif task_type == "sequence_prob":
         field_names = ["index", "loss"]
     elif task_type == "numeric":

--- a/eval_pipeline/main.py
+++ b/eval_pipeline/main.py
@@ -14,6 +14,7 @@ from tqdm.autonotebook import tqdm
 
 from eval_pipeline.dataset import Dataset, TaskType
 from eval_pipeline.models import Device, Model, BaseGPT3Model, ValidHFModel
+from eval_pipeline.openai_api import OpenaAIModelList
 
 
 def main():
@@ -129,8 +130,8 @@ def run_model(
     write the results to write_path incrementally."""
     write_path = Path(write_dir, model_name + ".csv")
     # TODO: find a way to avoid having to specify field names ahead of time
-    if task_type in ["classification_loss", "classification_acc", "classification"]:
-        field_names = ["index", "loss", "correct", "predicted", "total_logprob"]
+    if task_type in ["classification_loss", "classification", "classification_acc"]:
+        field_names = ["index", "loss", "correct", "predicted", "total_logprob", "ground_truth"]
     elif task_type == "sequence_prob":
         field_names = ["index", "loss"]
     elif task_type == "numeric":
@@ -198,21 +199,13 @@ def parse_args(args):
             "gpt-neo-1.3B",
             "gpt-neo-2.7B",
             "gpt-j-6B",
-            "ada",
-            "babbage",
-            "curie",
-            "davinci",
-            "text-ada-001",
-            "text-babbage-001",
-            "text-curie-001",
-            "text-davinci-001",
             "opt-125m",
             "opt-350m",
             "opt-1.3b",
             "opt-2.7b",
             "opt-6.7b",
             "opt-13b",
-        ],
+        ] + OpenaAIModelList,
         required=True,
     )
     parser.add_argument(

--- a/eval_pipeline/models.py
+++ b/eval_pipeline/models.py
@@ -27,7 +27,7 @@ from eval_pipeline.dataset import (
     TaskType,
 )
 from eval_pipeline.numeric_parser import BasicParser
-from eval_pipeline.openai_api import APIParameters, BaseGPT3Model, OpenAIModel, call_api
+from eval_pipeline.openai_api import APIParameters, BaseGPT3Model, OpenAIModel, call_api, OpenaAIModelList
 
 OPENAI_API_BASE_URL = "https://api.openai.com/v1/engines"
 load_dotenv()
@@ -56,10 +56,8 @@ ValidHFModel = Literal[
 ]
 valid_hf_models: tuple[ValidHFModel, ...] = get_args(ValidHFModel)
 
-# NOTE: due to limitations of get_args with nested Literals, we have to call it
-# multiple times
-valid_gpt3_models: tuple[OpenAIModel, ...] = [x for li in get_args(OpenAIModel) for x in get_args(li)]  # type: ignore
-
+# NOTE: due to limitations of get_args with nested Literals, we can't directly call get_args on OpenAIModel
+valid_gpt3_models = OpenaAIModelList
 Device = Literal["cuda:0", "cpu"]
 
 
@@ -519,6 +517,9 @@ class GPT3Model(Model):
             "correct": labels_correct,
             "predicted": labels_predicted,
             "total_logprob": total_logprobs,
+            "ground_truth": [
+                example.classes[example.answer_index] for example in examples
+            ],
         }
 
     def _evaluate_logodds(

--- a/eval_pipeline/models.py
+++ b/eval_pipeline/models.py
@@ -517,9 +517,6 @@ class GPT3Model(Model):
             "correct": labels_correct,
             "predicted": labels_predicted,
             "total_logprob": total_logprobs,
-            "ground_truth": [
-                example.classes[example.answer_index] for example in examples
-            ],
         }
 
     def _evaluate_logodds(

--- a/eval_pipeline/openai_api.py
+++ b/eval_pipeline/openai_api.py
@@ -9,6 +9,12 @@ from datetime import timedelta
 from typing import Optional, Union
 from ratelimit import sleep_and_retry, limits
 
+BaseGPT3List = [
+    "ada",
+    "babbage",
+    "curie",
+    "davinci",
+]
 
 BaseGPT3Model = Literal[
     "ada",
@@ -16,13 +22,26 @@ BaseGPT3Model = Literal[
     "curie",
     "davinci",
 ]
+
+InstructGPT3List = [
+    "text-ada-001",
+    "text-babbage-001",
+    "text-curie-001",
+    "text-davinci-001",
+    "text-davinci-002",
+    "text-davinci-003"
+]
+
 InstructGPT3Model = Literal[
     "text-ada-001",
     "text-babbage-001",
     "text-curie-001",
     "text-davinci-001",
+    "text-davinci-002",
+    "text-davinci-003"
 ]
 
+OpenaAIModelList = BaseGPT3List + InstructGPT3List
 OpenAIModel = Literal[BaseGPT3Model, InstructGPT3Model]
 
 


### PR DESCRIPTION
This fixes the colab notebook example. previously it was broken on python >= 3.9, due to a change in how get_args from typing worked. Google colab also now runs on python 3.9, as opposed to 3.8 previously. which is why we only are getting the errors now.

## get_args different behavior 3.8 vs 3.9
```py
from typing_extensions import Literal, get_args
BaseGPT3Model = Literal[
"ada",
"babbage",
"curie",
"davinci",
]
InstructGPT3Model = Literal[
"text-ada-001",
"text-babbage-001",
"text-curie-001",
"text-davinci-001",
]
OpenAIModel = Literal[BaseGPT3Model, InstructGPT3Model]
get_args(OpenAIModel)
```
For python <= 3.8
```
>>> get_args(OpenAIModel)
(typing_extensions.Literal['ada', 'babbage', 'curie', 'davinci'], typing_extensions.Literal['text-ada-001', 'text-babbage-001', 'text-curie-001', 'text-davinci-001'])
```
For python >= 3.9
```
>>> get_args(OpenAIModel)
('ada', 'babbage', 'curie', 'davinci', 'text-ada-001', 'text-babbage-001', 'text-curie-001', 'text-davinci-001')
```


## Testing out the changes
You can replace the first part of the colab file with my fork.
Also note that I deleted the line of matplotlib - it doesn't seem to be neccesary anymore, and seems to cause issues with saving svgs.
I also curled the  sample QA CSV so that users can just test it out quickly.
The colab, set up with my fork, is [here](https://colab.research.google.com/drive/1KDfTN888501QJM0VodmFyguyk0hfoU6h?usp=sharing)

```
#@title Set up script { display-mode: "form" }
#@markdown Run this cell to install the necessary packages (may take a few minutes)
%%shell
cd /content
rm -rf /content/inverse-scaling-eval-pipeline
git clone -b fix-fork --single-branch https://github.com/thejaminator/inverse-scaling-eval-pipeline.git
pip install git+https://github.com/thejaminator/inverse-scaling-eval-pipeline.git@fix-fork
curl -OJL https://raw.githubusercontent.com/naimenz/inverse-scaling-eval-pipeline/main/data/QA_bias-v2.csv
```
